### PR TITLE
[DO NOT MERGE] Stake: Create fix for CANLAB staking contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "cw-placeholder"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "cw-splitter"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -645,7 +645,7 @@ checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "gauge-adapter"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -658,11 +658,11 @@ dependencies = [
  "cw20-base 1.0.1",
  "thiserror",
  "wynd-utils",
- "wyndex",
+ "wyndex 1.1.2-canlab",
  "wyndex-factory",
  "wyndex-pair",
  "wyndex-pair-stable",
- "wyndex-stake",
+ "wyndex-stake 1.1.2-canlab",
 ]
 
 [[package]]
@@ -756,7 +756,7 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "junoswap-staking"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -774,10 +774,10 @@ dependencies = [
  "stake-cw20",
  "thiserror",
  "wasmswap",
- "wyndex",
+ "wyndex 1.1.2-canlab",
  "wyndex-factory",
  "wyndex-pair",
- "wyndex-stake",
+ "wyndex-stake 1.1.2-canlab",
 ]
 
 [[package]]
@@ -806,7 +806,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "nominated-trader"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -818,12 +818,12 @@ dependencies = [
  "cw20 1.0.1",
  "cw20-base 1.0.1",
  "thiserror",
- "wyndex",
+ "wyndex 1.1.2-canlab",
  "wyndex-factory",
  "wyndex-multi-hop",
  "wyndex-pair",
  "wyndex-pair-stable",
- "wyndex-stake",
+ "wyndex-stake 1.1.2-canlab",
 ]
 
 [[package]]
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "raw-migration"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1031,10 +1031,10 @@ dependencies = [
  "stake-cw20",
  "thiserror",
  "wasmswap",
- "wyndex",
+ "wyndex 1.1.2-canlab",
  "wyndex-factory",
  "wyndex-pair",
- "wyndex-stake",
+ "wyndex-stake 1.1.2-canlab",
 ]
 
 [[package]]
@@ -1326,11 +1326,11 @@ dependencies = [
  "cw-multi-test",
  "cw20 1.0.1",
  "cw20-base 1.0.1",
- "wyndex",
+ "wyndex 1.1.2-canlab",
  "wyndex-factory",
  "wyndex-multi-hop",
  "wyndex-pair",
- "wyndex-stake",
+ "wyndex-stake 1.1.2-canlab",
 ]
 
 [[package]]
@@ -1456,7 +1456,23 @@ dependencies = [
 
 [[package]]
 name = "wyndex"
+version = "1.1.2-canlab"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw20 1.0.1",
+ "cw20-base 1.0.1",
+ "itertools 0.10.5",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
+name = "wyndex"
 version = "1.1.2"
+source = "git+https://github.com/cosmorama/wynddex?tag=v1.1.2#acca3311673d9d7c990a88d910f4a03a9acf25fd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1471,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "wyndex-factory"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1485,14 +1501,14 @@ dependencies = [
  "cw20-base 1.0.1",
  "itertools 0.10.5",
  "thiserror",
- "wyndex",
+ "wyndex 1.1.2-canlab",
  "wyndex-pair",
- "wyndex-stake",
+ "wyndex-stake 1.1.2-canlab",
 ]
 
 [[package]]
 name = "wyndex-multi-hop"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1503,15 +1519,15 @@ dependencies = [
  "cw20 1.0.1",
  "cw20-base 1.0.1",
  "thiserror",
- "wyndex",
+ "wyndex 1.1.2-canlab",
  "wyndex-factory",
  "wyndex-pair",
- "wyndex-stake",
+ "wyndex-stake 1.1.2-canlab",
 ]
 
 [[package]]
 name = "wyndex-pair"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1522,14 +1538,14 @@ dependencies = [
  "cw20 1.0.1",
  "cw20-base 1.0.1",
  "proptest",
- "wyndex",
+ "wyndex 1.1.2-canlab",
  "wyndex-factory",
- "wyndex-stake",
+ "wyndex-stake 1.1.2-canlab",
 ]
 
 [[package]]
 name = "wyndex-pair-stable"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1543,14 +1559,14 @@ dependencies = [
  "derivative 0.3.1",
  "itertools 0.10.5",
  "proptest",
- "wyndex",
+ "wyndex 1.1.2-canlab",
  "wyndex-factory",
- "wyndex-stake",
+ "wyndex-stake 1.1.2-canlab",
 ]
 
 [[package]]
 name = "wyndex-stake"
-version = "1.1.2"
+version = "1.1.2-canlab"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1566,7 +1582,26 @@ dependencies = [
  "test-case",
  "thiserror",
  "wynd-utils",
- "wyndex",
+ "wyndex 1.1.2-canlab",
+ "wyndex-stake 1.1.2",
+]
+
+[[package]]
+name = "wyndex-stake"
+version = "1.1.2"
+source = "git+https://github.com/cosmorama/wynddex?tag=v1.1.2#acca3311673d9d7c990a88d910f4a03a9acf25fd"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers 1.0.1",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1",
+ "cw20 1.0.1",
+ "serde",
+ "thiserror",
+ "wynd-utils",
+ "wyndex 1.1.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["packages/*", "contracts/*", "tests"]
 
 [workspace.package]
-version = "1.1.2"
+version = "1.1.2-canlab"
 edition = "2021"
 license = "GPL 3.0"
 repository = "https://github.com/cosmorama/wynddex"

--- a/contracts/stake/Cargo.toml
+++ b/contracts/stake/Cargo.toml
@@ -40,3 +40,6 @@ cosmwasm-schema = { workspace = true }
 # standard libs
 anyhow = { workspace = true }
 test-case = { workspace = true }
+
+# hotfix for canlab migration
+wyndex-stake-v112 = { package = "wyndex-stake", git = "https://github.com/cosmorama/wynddex", tag = "v1.1.2" }

--- a/contracts/stake/src/msg.rs
+++ b/contracts/stake/src/msg.rs
@@ -169,8 +169,7 @@ pub enum QueryMsg {
 
 #[cw_serde]
 pub struct MigrateMsg {
-    /// Address of the account that can call [`ExecuteMsg::QuickUnbond`]
-    pub unbonder: Option<String>,
+    pub canlab_token_contract: String,
 }
 
 #[cw_serde]

--- a/contracts/stake/src/multitest.rs
+++ b/contracts/stake/src/multitest.rs
@@ -1,5 +1,6 @@
 mod delegate;
 mod distribution;
+mod migrate;
 mod quick_unbond;
 mod staking_rewards;
 mod suite;

--- a/contracts/stake/src/multitest/migrate.rs
+++ b/contracts/stake/src/multitest/migrate.rs
@@ -1,0 +1,410 @@
+use anyhow::Result as AnyResult;
+
+use cosmwasm_std::{assert_approx_eq, to_binary, Addr, Decimal, StdResult, Uint128};
+use cw20::{Cw20Coin, Cw20ExecuteMsg, MinterResponse};
+use cw20_base::msg::InstantiateMsg as Cw20InstantiateMsg;
+
+use cw_multi_test::{App, AppResponse, ContractWrapper, Executor};
+use wynd_curve_utils::{Curve, SaturatingLinear};
+use wyndex::{
+    asset::{AssetInfo, AssetInfoExt, AssetInfoValidated, AssetValidated},
+    stake::{InstantiateMsg, UnbondingPeriod},
+};
+
+use crate::msg::{
+    ExecuteMsg, MigrateMsg, QueryMsg, ReceiveDelegationMsg, WithdrawableRewardsResponse,
+};
+
+pub const SEVEN_DAYS: u64 = 604800;
+
+fn contract_stake_v112(app: &mut App) -> u64 {
+    let contract = Box::new(
+        ContractWrapper::new_with_empty(
+            wyndex_stake_v112::contract::execute,
+            wyndex_stake_v112::contract::instantiate,
+            wyndex_stake_v112::contract::query,
+        )
+        .with_migrate_empty(wyndex_stake_v112::contract::migrate),
+    );
+
+    app.store_code(contract)
+}
+
+fn contract_stake(app: &mut App) -> u64 {
+    let contract = Box::new(
+        ContractWrapper::new_with_empty(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        )
+        .with_migrate_empty(crate::contract::migrate),
+    );
+
+    app.store_code(contract)
+}
+
+pub(super) fn contract_token(app: &mut App) -> u64 {
+    let contract = Box::new(ContractWrapper::new_with_empty(
+        cw20_base::contract::execute,
+        cw20_base::contract::instantiate,
+        cw20_base::contract::query,
+    ));
+
+    app.store_code(contract)
+}
+
+#[derive(Debug)]
+pub struct SuiteBuilder {
+    pub cw20_contract: String,
+    pub tokens_per_power: Uint128,
+    pub min_bond: Uint128,
+    pub unbonding_periods: Vec<UnbondingPeriod>,
+    pub admin: Option<String>,
+    pub initial_balances: Vec<Cw20Coin>,
+    pub canlab_initial_balances: Vec<Cw20Coin>,
+}
+
+impl SuiteBuilder {
+    pub fn new() -> Self {
+        Self {
+            cw20_contract: "".to_owned(),
+            tokens_per_power: Uint128::new(1000),
+            min_bond: Uint128::new(5000),
+            unbonding_periods: vec![SEVEN_DAYS],
+            admin: None,
+            initial_balances: vec![],
+            canlab_initial_balances: vec![],
+        }
+    }
+
+    pub fn with_admin(mut self, admin: &str) -> Self {
+        self.admin = Some(admin.to_owned());
+        self
+    }
+
+    pub fn with_initial_balances(mut self, balances: Vec<(&str, u128)>) -> Self {
+        let initial_balances = balances
+            .into_iter()
+            .map(|(address, amount)| Cw20Coin {
+                address: address.to_owned(),
+                amount: amount.into(),
+            })
+            .collect::<Vec<Cw20Coin>>();
+        self.initial_balances = initial_balances;
+        self
+    }
+
+    pub fn with_canlab_initial_balances(mut self, balances: Vec<(&str, u128)>) -> Self {
+        let initial_balances = balances
+            .into_iter()
+            .map(|(address, amount)| Cw20Coin {
+                address: address.to_owned(),
+                amount: amount.into(),
+            })
+            .collect::<Vec<Cw20Coin>>();
+        self.canlab_initial_balances = initial_balances;
+        self
+    }
+
+    pub fn with_unbonding_periods(mut self, unbonding_periods: Vec<UnbondingPeriod>) -> Self {
+        self.unbonding_periods = unbonding_periods;
+        self
+    }
+
+    #[track_caller]
+    pub fn build(self) -> Suite {
+        let mut app: App = App::default();
+        let admin = Addr::unchecked("admin");
+
+        let token_id = contract_token(&mut app);
+
+        // Instantiate CANLAB token contract
+        let canlab_token_contract = app
+            .instantiate_contract(
+                token_id,
+                admin.clone(),
+                &Cw20InstantiateMsg {
+                    name: "canlab".to_owned(),
+                    symbol: "CANLAB".to_owned(),
+                    decimals: 3,
+                    initial_balances: self.canlab_initial_balances,
+                    mint: Some(MinterResponse {
+                        minter: "minter".to_owned(),
+                        cap: None,
+                    }),
+                    marketing: None,
+                },
+                &[],
+                "canlab",
+                None,
+            )
+            .unwrap();
+
+        let token_contract = app
+            .instantiate_contract(
+                token_id,
+                admin.clone(),
+                &Cw20InstantiateMsg {
+                    name: "vesting".to_owned(),
+                    symbol: "VEST".to_owned(),
+                    decimals: 9,
+                    initial_balances: self.initial_balances,
+                    mint: Some(MinterResponse {
+                        minter: "minter".to_owned(),
+                        cap: None,
+                    }),
+                    marketing: None,
+                },
+                &[],
+                "vesting",
+                None,
+            )
+            .unwrap();
+
+        // Instantiate original staking contract
+        let stake_id = contract_stake_v112(&mut app);
+        let stake_contract = app
+            .instantiate_contract(
+                stake_id,
+                admin.clone(),
+                &InstantiateMsg {
+                    cw20_contract: token_contract.to_string(),
+                    tokens_per_power: self.tokens_per_power,
+                    min_bond: self.min_bond,
+                    unbonding_periods: self.unbonding_periods,
+                    admin: self.admin,
+                    unbonder: Some("unbonder".to_owned()),
+                    max_distributions: 6,
+                },
+                &[],
+                "stake",
+                Some(admin.to_string()),
+            )
+            .unwrap();
+
+        Suite {
+            app,
+            stake_contract,
+            token_contract,
+            canlab_token_contract,
+        }
+    }
+}
+
+pub struct Suite {
+    pub app: App,
+    stake_contract: Addr,
+    token_contract: Addr,
+    canlab_token_contract: Addr,
+}
+
+impl Suite {
+    // update block's time to simulate passage of time
+    pub fn update_seconds(&mut self, time_update: u64) {
+        let mut block = self.app.block_info();
+        block.time = block.time.plus_seconds(time_update);
+        self.app.set_block(block);
+    }
+
+    // create a new distribution flow for staking
+    pub fn create_distribution_flow(
+        &mut self,
+        sender: &str,
+        manager: &str,
+        asset: AssetInfo,
+        rewards: Vec<(UnbondingPeriod, Decimal)>,
+    ) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            Addr::unchecked(sender),
+            self.stake_contract.clone(),
+            &ExecuteMsg::CreateDistributionFlow {
+                manager: manager.to_string(),
+                asset,
+                rewards,
+            },
+            &[],
+        )
+    }
+
+    // call to staking contract by sender
+    pub fn execute_fund_distribution_with_cw20(
+        &mut self,
+        executor: &str,
+        funds: AssetValidated,
+        curve: Curve,
+        token: Addr,
+    ) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            Addr::unchecked(executor),
+            token,
+            &Cw20ExecuteMsg::Send {
+                contract: self.stake_contract.to_string(),
+                amount: funds.amount,
+                msg: to_binary(&ReceiveDelegationMsg::Fund { curve })?,
+            },
+            &[],
+        )
+    }
+
+    pub fn increase_allowance_for_stake_contract(
+        &mut self,
+        token: &str,
+        sender: &str,
+        amount: u128,
+    ) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            Addr::unchecked(sender),
+            Addr::unchecked(token),
+            &Cw20ExecuteMsg::IncreaseAllowance {
+                spender: self.stake_contract.to_string(),
+                amount: amount.into(),
+                expires: None,
+            },
+            &[],
+        )
+    }
+
+    pub fn distribute_rewards(&mut self, sender: &str) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            Addr::unchecked(sender),
+            self.stake_contract.clone(),
+            &ExecuteMsg::DistributeRewards { sender: None },
+            &[],
+        )
+    }
+
+    // call to staking contract by sender
+    pub fn delegate(
+        &mut self,
+        sender: &str,
+        amount: u128,
+        unbonding_period: u64,
+    ) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            Addr::unchecked(sender),
+            self.token_contract.clone(),
+            &Cw20ExecuteMsg::Send {
+                contract: self.stake_contract.to_string(),
+                amount: amount.into(),
+                msg: to_binary(&ReceiveDelegationMsg::Delegate {
+                    unbonding_period,
+                    delegate_as: Some(sender.to_owned()),
+                })?,
+            },
+            &[],
+        )
+    }
+
+    // create a new distribution flow for staking
+    pub fn migrate(
+        &mut self,
+        sender: &str,
+        contract: Addr,
+        code_id: u64,
+        canlab_token_contract: &str,
+    ) -> AnyResult<AppResponse> {
+        self.app.migrate_contract(
+            Addr::unchecked(sender),
+            contract,
+            &MigrateMsg {
+                canlab_token_contract: canlab_token_contract.to_owned(),
+            },
+            code_id,
+        )
+    }
+
+    pub fn query_withdrawable_rewards(&self, owner: &str) -> StdResult<Vec<AssetValidated>> {
+        let resp: WithdrawableRewardsResponse = self.app.wrap().query_wasm_smart(
+            self.stake_contract.clone(),
+            &QueryMsg::WithdrawableRewards {
+                owner: owner.to_owned(),
+            },
+        )?;
+        Ok(resp.rewards)
+    }
+}
+
+#[test]
+fn migrate_existing_distribution_curve() {
+    let sponsor = "sponsor".to_owned();
+    let user = "user".to_owned();
+    let unbonding_period = 1000u64;
+    let distribution = 50_000_000u128;
+
+    let mut suite = SuiteBuilder::new()
+        .with_admin("admin")
+        .with_unbonding_periods(vec![unbonding_period])
+        // simulates user having tokens to stake
+        .with_initial_balances(vec![(&user, 100_000)])
+        .with_canlab_initial_balances(vec![(&sponsor, distribution)])
+        .build();
+
+    let canlab_token_contract = suite.canlab_token_contract.clone();
+
+    suite
+        .increase_allowance_for_stake_contract(
+            canlab_token_contract.as_str(),
+            &sponsor,
+            distribution,
+        )
+        .unwrap();
+    suite
+        .create_distribution_flow(
+            "admin",
+            &sponsor,
+            AssetInfo::Token(canlab_token_contract.to_string()),
+            vec![(unbonding_period, Decimal::one())],
+        )
+        .unwrap();
+
+    suite.delegate(&user, 100_000, unbonding_period).unwrap();
+
+    // Fund both distribution flows
+    suite
+        .execute_fund_distribution_with_cw20(
+            &sponsor,
+            AssetInfoValidated::Token(canlab_token_contract.clone()).with_balance(distribution),
+            Curve::SaturatingLinear(SaturatingLinear {
+                min_x: 1676329200,
+                min_y: Uint128::new(distribution),
+                max_x: 1707865200,
+                max_y: Uint128::zero(),
+            }),
+            canlab_token_contract.clone(),
+        )
+        .unwrap();
+
+    // 10% of seconds in year
+    suite.update_seconds(3_153_600);
+
+    // because of incorrect curve, no rewards are being distributed
+    suite.distribute_rewards(&sponsor).unwrap();
+    assert_eq!(
+        suite.query_withdrawable_rewards(&user).unwrap(),
+        vec![AssetInfoValidated::Token(canlab_token_contract.clone()).with_balance(0u128)]
+    );
+
+    // store new version
+    let new_code_id = contract_stake(&mut suite.app);
+    // it maps current configuration on mainnet
+    suite
+        .migrate(
+            "admin",
+            suite.stake_contract.clone(),
+            new_code_id,
+            canlab_token_contract.as_str(),
+        )
+        .unwrap();
+
+    // Now curve is fixed and started distributing rewards
+    suite.update_seconds(3_153_600);
+
+    suite.distribute_rewards(&sponsor).unwrap();
+    // some rewards started to get distributed
+    assert_approx_eq!(
+        suite.query_withdrawable_rewards(&user).unwrap()[0].amount,
+        Uint128::new(5_000_000u128),
+        "0.00001",
+        "10% of whole distribution, more or less"
+    );
+}


### PR DESCRIPTION
Because of our mistake, CANLAB while providing fund for distributing rewards provided incorrect distribution curve following our suggestions. 
This fix is a special version for CANLAB staking contract: `juno1wjcak50p8y7ajyu5n4u88s8ah58fa520442flthy7dq55v6fatqqrd395z`
It migrates contract, updating state storage to allow start of reward distribution.

Parameter `canlab_token_contract` is used as a safety mechanism - during migration algorithm will check, if staking contract contains that token in its reward distribution state storage. Only two contracts have them (CANLABs), and those are the ones we want to migrate.

This PR is not meant to be merged. I will create a special release version and create proposal to migrate that contract.